### PR TITLE
Fix config precision

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -6,7 +6,7 @@ paths:
 model:
   name:      "Qwen2.5-32B"
   repo_id:   "Qwen/Qwen2.5-32B"
-  precision: "int4"
+  precision: "int8"
 
 alveo:
   device_id: 0


### PR DESCRIPTION
## Summary
- use int8 quantization precision by default

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a9cb8177c83288ea27a3ca59c6990