### PR TITLE
Fix code style and lambda usage

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -6,36 +6,38 @@ import requests
 import time
 import yaml
 
+
 def load_config(config_path):
     """Загрузка конфигурационного файла."""
-    with open(config_path, 'r') as f:
+    with open(config_path, "r") as f:
         return yaml.safe_load(f)
+
 
 def test_generate(url, prompt, max_tokens=None, temperature=None):
     """Тест генерации текста через API."""
     headers = {
         "Content-Type": "application/json",
     }
-    
+
     data = {
         "prompt": prompt,
     }
-    
+
     if max_tokens is not None:
         data["max_tokens"] = max_tokens
-    
+
     if temperature is not None:
         data["temperature"] = temperature
-    
+
     print(f"\nОтправка запроса на {url}:")
     print(f"Промпт: {prompt}")
-    
+
     start_time = time.time()
     response = requests.post(url, headers=headers, json=data)
     end_time = time.time()
-    
+
     print(f"Статус ответа: {response.status_code}")
-    
+
     if response.status_code == 200:
         result = response.json()
         print(f"\nСгенерированный текст:")
@@ -49,6 +51,7 @@ def test_generate(url, prompt, max_tokens=None, temperature=None):
         print(f"Время запроса: {(end_time - start_time) * 1000:.2f}ms")
     else:
         print(f"Ошибка: {response.text}")
+
 
 def test_status(url):
     """Проверка статуса сервера."""
@@ -64,18 +67,43 @@ def test_status(url):
     except Exception as e:
         print(f"Ошибка соединения: {str(e)}")
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Тестирование API сервера инференса")
-    parser.add_argument("--config", type=str, default="../configs/config.yaml", help="Путь к конфигурационному файлу")
+    parser = argparse.ArgumentParser(
+        description="Тестирование API сервера инференса"
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="../configs/config.yaml",
+        help="Путь к конфигурационному файлу",
+    )
     parser.add_argument("--host", type=str, help="Хост сервера")
     parser.add_argument("--port", type=int, help="Порт сервера")
-    parser.add_argument("--prompt", type=str, default="Привет! Расскажи мне о AMD Alveo U250.", help="Промпт для генерации")
-    parser.add_argument("--max-tokens", type=int, help="Максимальное количество токенов для генерации")
-    parser.add_argument("--temperature", type=float, help="Параметр temperature для генерации")
-    parser.add_argument("--status", action="store_true", help="Проверить только статус сервера")
-    
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="Привет! Расскажи мне о AMD Alveo U250.",
+        help="Промпт для генерации",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        help="Максимальное количество токенов для генерации",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        help="Параметр temperature для генерации",
+    )
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Проверить только статус сервера",
+    )
+
     args = parser.parse_args()
-    
+
     # Загружаем конфигурацию если не указаны хост и порт
     if not args.host or not args.port:
         config = load_config(args.config)
@@ -84,9 +112,9 @@ if __name__ == "__main__":
     else:
         host = args.host
         port = args.port
-    
+
     base_url = f"http://{host}:{port}"
-    
+
     if args.status:
         test_status(base_url)
     else:

--- a/utils/convert_model_for_alveo.py
+++ b/utils/convert_model_for_alveo.py
@@ -9,10 +9,17 @@ TVM runtime bundle.
   https://docs.xilinx.com/r/2.5-English/ug1414-vitis-ai
 """
 
-import argparse, os, subprocess, tvm
+import argparse
+import os
+import subprocess
+import tvm
 from tvm import relay
 
-run = lambda cmd: subprocess.check_call(cmd, shell=True)
+
+def run(cmd):
+    """Execute a shell command."""
+    subprocess.check_call(cmd, shell=True)
+
 
 ARCH = "/opt/vitis_ai/compiler/arch/DPUCADF8H/U250/arch.json"
 
@@ -23,7 +30,8 @@ def export_ts(src_dir, out_ts):
         f"from transformers import AutoModelForCausalLM, AutoTokenizer\n"
         f"import torch\n"
         f"tok = AutoTokenizer.from_pretrained('{src_dir}')\n"
-        f"mdl = AutoModelForCausalLM.from_pretrained('{src_dir}', torchscript=True)\n"
+        f"mdl = AutoModelForCausalLM.from_pretrained('{src_dir}', "
+        f"torchscript=True)\n"
         f"t = tok.encode('Hello', return_tensors='pt')\n"
         f"ts = torch.jit.trace(mdl, t)\n"
         f"ts.save('{out_ts}')\n"

--- a/utils/download_model.py
+++ b/utils/download_model.py
@@ -30,13 +30,23 @@ def download_model(model_name, output_dir) -> Literal[True]:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Download Transformer model")
-    parser.add_argument("--config", type=str, required=True, help="Path to config.yaml")
+    parser = argparse.ArgumentParser(
+        description="Download Transformer model"
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to config.yaml",
+    )
     args = parser.parse_args()
 
     config = load_config(args.config)
     model_name = config["model"]["repo_id"]
-    model_dir = os.path.join(config["paths"]["models_dir"], config["model"]["name"])
+    model_dir = os.path.join(
+        config["paths"]["models_dir"],
+        config["model"]["name"],
+    )
 
     os.makedirs(model_dir, exist_ok=True)
     download_model(model_name, model_dir)


### PR DESCRIPTION
## Summary
- split multi-imports
- replace lambda assigned to `run` with a function
- break long lines and clean whitespace across utils and tests

## Testing
- `pycodestyle utils/convert_model_for_alveo.py utils/download_model.py utils/inference_server.py test_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684a9cbd278c8328bff538f1d4ce3f0a