### PR TITLE
Use config base_dir in setup scripts

### DIFF
--- a/scripts/01_prepare_system.sh
+++ b/scripts/01_prepare_system.sh
@@ -7,13 +7,15 @@
 #
 
 set -euo pipefail
-BASE="$HOME/Apps/amd-llm"
-mkdir -p "$BASE"
+CFG="configs/config.yaml"
 
 sudo apt update && sudo apt -y upgrade
 sudo apt install -y build-essential git wget jq cmake dkms pciutils \
     python3-venv python3-pip
 sudo snap install yq
+
+BASE="$(yq '.paths.base_dir' "$CFG")"
+mkdir -p "$BASE"
 
 # Python venv
 pip install --upgrade pip

--- a/utils/setup_env.sh
+++ b/utils/setup_env.sh
@@ -2,7 +2,8 @@
 # Environment activator for Alveo U250  +  Vitis‑AI 2.5
 
 source /opt/xilinx/xrt/setup.sh
-BASE="$HOME/Apps/amd-llm"
+CFG="configs/config.yaml"
+BASE="$(yq '.paths.base_dir' "$CFG")"
 source "$BASE/venv/bin/activate"
 
 VAI_HOME="$BASE/Vitis-AI-2.5"


### PR DESCRIPTION
## Summary
- use `paths.base_dir` from config.yaml in setup scripts

## Testing
- `bash -n utils/setup_env.sh`
- `bash -n scripts/01_prepare_system.sh`


------
https://chatgpt.com/codex/tasks/task_e_684a9cc1e73c8328ab48bedb8ef2cfc8